### PR TITLE
feat: mark internal atoms as private

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.4.1",
     "jest-environment-jsdom": "^29.4.1",
-    "jotai": "^2.0.0",
+    "jotai": "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz",
     "microbundle": "^0.15.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.4.1",
     "jest-environment-jsdom": "^29.4.1",
-    "jotai": "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz",
+    "jotai": "^2.0.3",
     "microbundle": "^0.15.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.3",

--- a/src/atomWithProxy.ts
+++ b/src/atomWithProxy.ts
@@ -48,6 +48,7 @@ export function atomWithProxy<Value extends object>(
   options?: Options
 ) {
   const baseAtom = atom(snapshot(proxyObject))
+  baseAtom.debugPrivate = true
   baseAtom.onMount = (setValue) => {
     const callback = () => {
       setValue(snapshot(proxyObject))

--- a/src/atomWithProxy.ts
+++ b/src/atomWithProxy.ts
@@ -48,7 +48,10 @@ export function atomWithProxy<Value extends object>(
   options?: Options
 ) {
   const baseAtom = atom(snapshot(proxyObject))
-  baseAtom.debugPrivate = true
+  if (process.env.NODE_ENV !== 'production') {
+    baseAtom.debugPrivate = true
+  }
+
   baseAtom.onMount = (setValue) => {
     const callback = () => {
       setValue(snapshot(proxyObject))

--- a/yarn.lock
+++ b/yarn.lock
@@ -4990,9 +4990,10 @@ jest@^29.4.1:
     import-local "^3.0.2"
     jest-cli "^29.4.1"
 
-"jotai@https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz":
-  version "2.0.2"
-  resolved "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz#85bdb3e7a19daad7a3cbdc3b12eda7329b733222"
+jotai@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.0.3.tgz#3b67cda9f6d5feb70a14db0b842a9873aacda8b5"
+  integrity sha512-MMjhSPAL3RoeZD9WbObufRT2quThEAEknHHridf2ma8Ml7ZVQmUiHk0ssdbR3F0h3kcwhYqSGJ59OjhPge7RRg==
 
 js-sdsl@^4.1.4:
   version "4.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4990,10 +4990,9 @@ jest@^29.4.1:
     import-local "^3.0.2"
     jest-cli "^29.4.1"
 
-jotai@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.0.0.tgz#3938ad0166130417811bb57ec2de8abeb24bd948"
-  integrity sha512-04G0CRZQgp3xrFAezd6X14psZ2TRGekHeYMBcbDJ/BR8ZJQPS+j0YkMTxUxyG58HJnN2+adfj5sWQWoqgtp1XQ==
+"jotai@https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz":
+  version "2.0.2"
+  resolved "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz#85bdb3e7a19daad7a3cbdc3b12eda7329b733222"
 
 js-sdsl@^4.1.4:
   version "4.3.0"
@@ -6273,10 +6272,10 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-proxy-compare@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.4.0.tgz#90f6abffe734ef86d8e37428c5026268606a9c1b"
-  integrity sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg==
+proxy-compare@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.5.0.tgz#0387c5e4d283ba9b1c0353bb20def4449b06bbd2"
+  integrity sha512-f1us0OsVAJ3tdIMXGQx2lmseYS4YXe4W+sKF5g5ww/jV+5ogMadPt+sIZ+88Ga9kvMJsrRNWzCrKPpr6pMWYbA==
 
 psl@^1.1.33:
   version "1.9.0"
@@ -7471,11 +7470,11 @@ validate-npm-package-license@^3.0.1:
     spdx-expression-parse "^3.0.0"
 
 valtio@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.9.0.tgz#d5d9f664319eaf18dd98f758d50495eca28eb0b8"
-  integrity sha512-mQLFsAlKbYascZygFQh6lXuDjU5WHLoeZ8He4HqMnWfasM96V6rDbeFkw1XeG54xycmDonr/Jb4xgviHtuySrA==
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.10.3.tgz#273eda9ba6459869798b4f58c84514e18fb80ed8"
+  integrity sha512-t3Ez/+baJ+Z5tIyeaI6nCAbW/hrmcq2jditwg/X++o5IvCdiGirQKTOv1kJq0glgUo13v5oABCVGcinggBfiKw==
   dependencies:
-    proxy-compare "2.4.0"
+    proxy-compare "2.5.0"
     use-sync-external-store "1.2.0"
 
 vary@~1.1.2:


### PR DESCRIPTION
### Checklist 

- [x] Check with Daishi if we should wrap the `debugPrivate` assignment in the dev-only flag now or do it later as it may require tooling changes
- [x] Update the `jotai` version to `2.0.3` once released